### PR TITLE
fix core-js imports

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,7 +4,8 @@ import React from 'react';
 import { Provider as PaperProvider } from 'react-native-paper';
 import { ThemeProvider } from 'styled-components'
 import { ToastProvider } from 'react-native-styled-toast'
-import 'core-js/stable';
+import 'core-js/internals/is-constructor';
+import 'core-js/internals/microtask';
 import OpenPixDemo from './src/OpenPixDemo';
 
 // Toast Theme


### PR DESCRIPTION
Core-js/stable was getting an maximum call stack size error when building. Changed the imports and the demo was working as expected again. 
I don't know if it's about a new version of the package or something related.